### PR TITLE
Fix position and size of ‘groepsnaam’ text

### DIFF
--- a/js/aankondiging.js
+++ b/js/aankondiging.js
@@ -8,7 +8,7 @@ backgroundImage.makeDraggable(canvas);
 let topText = new TextDrawable({font: "Bebas Neue", linespacing: 0.2, color: "white", allCaps: true, context:context,
     xPosition: 30, yPosition: 100, maxWidth:1940, maxHeight:400, inputID:"titelText"});
 let groepsnaam = new TextDrawable({font: "BebasNeueBook", linespacing: 0, color: "white", allCaps : true, context:context,
-    xPosition: 243, yPosition: 1843, doDynamicSize: false, fontSize: 70.5, doCenter: false, inputID: "groepsnaam",});
+    xPosition: 243, yPosition: 1847, doDynamicSize: false, fontSize: 68, doCenter: false, inputID: "groepsnaam",});
 let ondertitel = new TextDrawable({font: "BebasNeueBook", linespacing: 0.2, color: "white", allCaps : true, context:context,
     xPosition: 0, yPosition: 600, maxWidth: 2000, doDynamicSize: false, fontSize: 72.5, inputID: "onderTitel"});
 ondertitel.makeDraggable();


### PR DESCRIPTION
The _groepsnaam_ text is a couple of pixels off (see screenshots); these changes make it align perfectly.

![Screenshot_20240304_205523](https://github.com/MarcelBostelaar/test.github.io/assets/16049456/ebb62677-2a70-419d-864f-3390ebe91152)
![Screenshot_20240304_205439](https://github.com/MarcelBostelaar/test.github.io/assets/16049456/2064174c-30de-4fe7-82bc-8a715de149e8)
